### PR TITLE
Argument lists are no longer allowed to be incorrect

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,5 +1,7 @@
 import           Data.Attoparsec.ByteString.Char8
 import qualified Data.ByteString.Char8 as BS8
+import           Data.Either
+import           Test.Hspec
 import           Test.QuickCheck
 import           TestData
 import           Text.PrettyPrint.HughesPJ
@@ -22,7 +24,15 @@ testQuery q
 
 
 main :: IO ()
-main = do
-  quickCheck $ testQuery @User
-  quickCheck $ testQuery @Account
+main = hspec $ do
+  describe "roundtrip parser" $ do
+    it "should roundtrip for User" $
+      property $ testQuery @User
+    it "should roundtrip for Account" $
+      property $ testQuery @Account
+
+  describe "invalid arguments" $ do
+    it "should fail if passed a fake argument" $ do
+      parseOnly (queryParser @User) "{ userId(NOT_A_REAL_ARG: False) }"
+        `shouldSatisfy` isLeft
 


### PR DESCRIPTION
I got rid of the raw args stuff. Instead we fold the `Args args` type, and generate a `Permutation Parser (Args args)` for it. This lets us statically describe the arguments and their types to the parser, without caring the order they're parsed in. The result: the parser will bail if you ask it to parse something that isn't allowed by the schema :heart_eyes: 

Also I added a test case, and transformed the old quickcheck tests into hspecs. I'll follow this PR up with more testing.

also I renamed `gIncrParser` because it's no longer an incremental parser.

Fixes #18 