### PR TITLE
Chapter 7: In which the parser becomes variable-aware

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -35,6 +35,7 @@ dependencies:
   - QuickCheck
   - hspec
   - parser-combinators
+  - mtl
 
 default-extensions:
   - DeriveGeneric

--- a/src/Weft/Generics/QueryParser.hs
+++ b/src/Weft/Generics/QueryParser.hs
@@ -137,7 +137,7 @@ parseRawArgValue = choice
         -- know it's the right type inside of the vars list
         Just res -> pure res
         Nothing -> lift (empty <?> ("Undefined variable " ++ ident))
-  , lift (char '"') >> (:) <$> pure '"' <*> lift parseStringValue
+  , lift $ (char '"') >> (:) <$> pure '"' <*> parseStringValue
   , lift $ many1 $ satisfy $ \c -> all ($ c)
       [ not . Data.Char.isSpace
       , (/= ')')

--- a/src/Weft/Generics/QueryParser.hs
+++ b/src/Weft/Generics/QueryParser.hs
@@ -79,21 +79,28 @@ instance ( KnownSymbol name
 class GQueryParser (rq :: * -> *) where
   gQueryParser :: ReaderT Vars Parser (rq x)
 
-instance {-# OVERLAPPABLE #-} GQueryParser fq => GQueryParser (M1 a b fq) where
+instance {-# OVERLAPPABLE #-} GQueryParser fq
+      => GQueryParser (M1 a b fq) where
   gQueryParser = M1 <$> gQueryParser
 
-instance ( GPermFieldsParser (fq :*: gq)) => GQueryParser (fq :*: gq) where
+instance ( GPermFieldsParser (fq :*: gq))
+      => GQueryParser (fq :*: gq) where
   gQueryParser = intercalateEffect (lift skipSpace) gPermFieldsParser
 
-instance GPermFieldsParser (M1 _1 _2 (K1 _3 f)) => GQueryParser (M1 _1 _2 (K1 _3 f)) where
+instance GPermFieldsParser (M1 _1 _2 (K1 _3 f))
+      => GQueryParser (M1 _1 _2 (K1 _3 f)) where
   gQueryParser = runPermutation gPermFieldsParser
 
 
 ------------------------------------------------------------------------------
 -- |
-parseOptionalArgs :: forall args. (ParseArgs args, IsAllMaybe args) => ReaderT Vars Parser (Args args)
+parseOptionalArgs
+    :: ( ParseArgs args
+       , IsAllMaybe args
+       )
+    => ReaderT Vars Parser (Args args)
 parseOptionalArgs =
-  case isAllMaybe @args of
+  case isAllMaybe of
     Nothing -> parseArgList
     Just argsOfNothing ->
       fmap (fromMaybe argsOfNothing)

--- a/src/Weft/Generics/QueryParser.hs
+++ b/src/Weft/Generics/QueryParser.hs
@@ -5,9 +5,11 @@ module Weft.Generics.QueryParser
 
 import           Control.Applicative
 import           Control.Applicative.Permutations
+import           Control.Monad.Reader
 import           Data.Attoparsec.ByteString.Char8
 import qualified Data.ByteString.Char8 as BS
 import           Data.Char
+import qualified Data.Map as M
 import           Data.Maybe
 import           Data.Proxy
 import           GHC.Generics
@@ -21,14 +23,17 @@ type HasQueryParser record =
      , GQueryParser (Rep (record 'Query))
      )
 
-incrParser :: HasQueryParser record => Parser (record 'Query)
+incrParser :: HasQueryParser record => ReaderT Vars Parser (record 'Query)
 incrParser = fmap to gQueryParser
+
+
+type Vars = M.Map String String
 
 
 ------------------------------------------------------------------------------
 -- |
 class GPermFieldsParser (rq :: * -> *) where
-  gPermFieldsParser :: Permutation Parser (rq x)
+  gPermFieldsParser :: Permutation (ReaderT Vars Parser) (rq x)
 
 instance {-# OVERLAPPABLE #-} GPermFieldsParser fq => GPermFieldsParser (M1 a b fq) where
   gPermFieldsParser = M1 <$> gPermFieldsParser
@@ -43,8 +48,8 @@ instance (KnownSymbol name, ParseArgs args, IsAllMaybe args)
       => GPermFieldsParser (M1 S ('MetaSel ('Just name) _1 _2 _3)
                          (K1 _4 (Maybe (Args args, ())))) where
   gPermFieldsParser = fmap (M1 . K1) $ toPermutationWithDefault Nothing $ do
-    _ <- string $ BS.pack $ symbolVal $ Proxy @name
-    skipSpace
+    _ <- lift $ string $ BS.pack $ symbolVal $ Proxy @name
+    lift skipSpace
     args <- parseOptionalArgs @args
     pure $ Just (args, ())
 
@@ -56,15 +61,15 @@ instance ( KnownSymbol name
          ) => GPermFieldsParser (M1 S ('MetaSel ('Just name) _1 _2 _3)
                                     (K1 _4 (Maybe (Args args, t 'Query)))) where
   gPermFieldsParser = fmap (M1 . K1) $ toPermutationWithDefault Nothing $ do
-    _ <- string $ BS.pack $ symbolVal $ Proxy @name
-    skipSpace
+    _ <- lift $ string $ BS.pack $ symbolVal $ Proxy @name
+    lift skipSpace
     args <- parseOptionalArgs @args
-    skipSpace
-    _ <- char '{'
-    skipSpace
+    lift skipSpace
+    _ <- lift $ char '{'
+    lift skipSpace
     z <- incrParser
-    _ <- char '}'
-    skipSpace
+    _ <- lift $ char '}'
+    lift skipSpace
     pure $ Just (args, z)
 
 
@@ -72,13 +77,13 @@ instance ( KnownSymbol name
 ------------------------------------------------------------------------------
 -- |
 class GQueryParser (rq :: * -> *) where
-  gQueryParser :: Parser (rq x)
+  gQueryParser :: ReaderT Vars Parser (rq x)
 
 instance {-# OVERLAPPABLE #-} GQueryParser fq => GQueryParser (M1 a b fq) where
   gQueryParser = M1 <$> gQueryParser
 
 instance ( GPermFieldsParser (fq :*: gq)) => GQueryParser (fq :*: gq) where
-  gQueryParser = intercalateEffect skipSpace gPermFieldsParser
+  gQueryParser = intercalateEffect (lift skipSpace) gPermFieldsParser
 
 instance GPermFieldsParser (M1 _1 _2 (K1 _3 f)) => GQueryParser (M1 _1 _2 (K1 _3 f)) where
   gQueryParser = runPermutation gPermFieldsParser
@@ -86,7 +91,7 @@ instance GPermFieldsParser (M1 _1 _2 (K1 _3 f)) => GQueryParser (M1 _1 _2 (K1 _3
 
 ------------------------------------------------------------------------------
 -- |
-parseOptionalArgs :: forall args. (ParseArgs args, IsAllMaybe args) => Parser (Args args)
+parseOptionalArgs :: forall args. (ParseArgs args, IsAllMaybe args) => ReaderT Vars Parser (Args args)
 parseOptionalArgs =
   case isAllMaybe @args of
     Nothing -> parseArgList
@@ -94,67 +99,67 @@ parseOptionalArgs =
       fmap (fromMaybe argsOfNothing)
         $ optional parseArgList
 
-parseArgList :: ParseArgs args => Parser (Args args)
+parseArgList :: ParseArgs args => ReaderT Vars Parser (Args args)
 parseArgList = do
-  _ <- char '('
-  z <- intercalateEffect (skipSpace >> char ',' >> skipSpace) $ parseArgs
-  _ <- char ')'
+  _ <- lift $ char '('
+  z <- intercalateEffect (lift $ skipSpace >> char ',' >> skipSpace) $ parseArgs
+  _ <- lift $ char ')'
   pure z
 
 
-parseAnArg :: Read a => String -> Parser a
+parseAnArg :: Read a => String -> ReaderT Vars Parser a
 parseAnArg arg_name = do
-  skipSpace
-  _ <- string $ BS.pack arg_name
-  skipSpace
-  _ <- char ':'
-  skipSpace
+  lift skipSpace
+  _ <- lift $ string $ BS.pack arg_name
+  lift skipSpace
+  _ <- lift $ char ':'
+  lift skipSpace
   -- TODO(sandy): make this less shitty
   result <- parseRawArgValue
   pure $ read result
 
 
-parseRawArgValue :: Parser String
+parseRawArgValue :: ReaderT Vars Parser String
 parseRawArgValue = choice
-  [ char '"' >> (:) <$> pure '"' <*> parseStringValue
-  , many1 $ satisfy $ \c -> all ($ c)
+  [ lift (char '"') >> (:) <$> pure '"' <*> parseStringValue
+  , lift $ many1 $ satisfy $ \c -> all ($ c)
       [ not . Data.Char.isSpace
       , (/= ')')
       ]
   ]
 
-parseStringValue :: Parser String
+parseStringValue :: ReaderT Vars Parser String
 parseStringValue = do
-  c <- peekChar
+  c <- lift peekChar
   case c of
-    Just '"' -> char '"' >> pure "\""
+    Just '"' -> lift (char '"') >> pure "\""
     Just '\\' -> do
-      c1 <- anyChar
-      c2 <- anyChar
+      c1 <- lift anyChar
+      c2 <- lift anyChar
       (++) <$> pure (c1 : c2 : [])
            <*> parseStringValue
-    Just _ -> (:) <$> anyChar
+    Just _ -> (:) <$> lift anyChar
                   <*> parseStringValue
     Nothing -> empty
 
 
 ------------------------------------------------------------------------------
 -- |
-queryParser :: (HasEmptyQuery record, HasQueryParser record) => Parser (record 'Query)
+queryParser :: (HasEmptyQuery record, HasQueryParser record) => ReaderT Vars Parser (record 'Query)
 queryParser = do
-  _ <- char '{'
-  _ <- skipSpace
+  _ <- lift $ char '{'
+  _ <- lift skipSpace
   p <- incrParser
-  _ <- skipSpace
-  _ <- char '}'
-  _ <- skipSpace
+  _ <- lift skipSpace
+  _ <- lift $ char '}'
+  _ <- lift skipSpace
   pure p
 
 
 ------------------------------------------------------------------------------
 -- |
 class ParseArgs (args :: [(Symbol, *)]) where
-  parseArgs :: Permutation Parser (Args args)
+  parseArgs :: Permutation (ReaderT Vars Parser) (Args args)
 
 instance ParseArgs '[] where
   parseArgs = pure ANil

--- a/src/Weft/Generics/QueryParser.hs
+++ b/src/Weft/Generics/QueryParser.hs
@@ -130,7 +130,7 @@ parseRawArgValue = choice
         -- know it's the right type inside of the vars list
         Just res -> pure res
         Nothing -> lift (empty <?> ("Undefined variable " ++ ident))
-  , lift (char '"') >> (:) <$> pure '"' <*> parseStringValue
+  , lift (char '"') >> (:) <$> pure '"' <*> lift parseStringValue
   , lift $ many1 $ satisfy $ \c -> all ($ c)
       [ not . Data.Char.isSpace
       , (/= ')')
@@ -138,17 +138,17 @@ parseRawArgValue = choice
       ]
   ]
 
-parseStringValue :: ReaderT Vars Parser String
+parseStringValue :: Parser String
 parseStringValue = do
-  c <- lift peekChar
+  c <- peekChar
   case c of
-    Just '"' -> lift (char '"') >> pure "\""
+    Just '"' -> char '"' >> pure "\""
     Just '\\' -> do
-      c1 <- lift anyChar
-      c2 <- lift anyChar
+      c1 <- anyChar
+      c2 <- anyChar
       (++) <$> pure (c1 : c2 : [])
            <*> parseStringValue
-    Just _ -> (:) <$> lift anyChar
+    Just _ -> (:) <$> anyChar
                   <*> parseStringValue
     Nothing -> empty
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -13,8 +13,7 @@ import           Weft.Types
 import           Weft.Internal.Types
 
 testQuery
-    :: forall record
-     . ( Eq (record 'Query)
+    :: ( Eq (record 'Query)
        , Wefty record
        )
     => record 'Query -> Bool
@@ -23,7 +22,7 @@ testQuery q
   . parseOnly (flip runReaderT mempty queryParser)
   . BS8.pack
   . render
-  $ pprQuery @record q
+  $ pprQuery q
 
 
 main :: IO ()

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -20,7 +20,7 @@ testQuery
     => record 'Query -> Bool
 testQuery q
   = (== Right q)
-  . parseOnly (flip runReaderT mempty $ queryParser @record)
+  . parseOnly (flip runReaderT mempty queryParser)
   . BS8.pack
   . render
   $ pprQuery @record q
@@ -36,12 +36,14 @@ main = hspec $ do
 
   describe "invalid arguments" $ do
     it "should fail if passed a fake argument" $ do
-      parseOnly (flip runReaderT mempty $ queryParser @User) "{ userId(NOT_A_REAL_ARG: False) }"
+      parseOnly (flip runReaderT mempty $ queryParser @User)
+                "{ userId(NOT_A_REAL_ARG: False) }"
         `shouldSatisfy` isLeft
 
   describe "variables" $ do
     it "should fail if referencing an unknown var" $ do
-      parseOnly (flip runReaderT mempty $ queryParser @User) "{ userId(arg: $missing_var) }"
+      parseOnly (flip runReaderT mempty $ queryParser @User)
+                "{ userId(arg: $missing_var) }"
         `shouldSatisfy` isLeft
     it "should inline a known variable" $ do
       parseOnly (flip runReaderT (M.singleton "known" "\"a string\"")

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,6 +1,8 @@
+import           Control.Monad.Reader
 import           Data.Attoparsec.ByteString.Char8
 import qualified Data.ByteString.Char8 as BS8
 import           Data.Either
+import qualified Data.Map as M
 import           Test.Hspec
 import           Test.QuickCheck
 import           TestData
@@ -8,6 +10,7 @@ import           Text.PrettyPrint.HughesPJ
 import           Weft.Generics.PprQuery
 import           Weft.Generics.QueryParser
 import           Weft.Types
+import           Weft.Internal.Types
 
 testQuery
     :: forall record
@@ -17,7 +20,7 @@ testQuery
     => record 'Query -> Bool
 testQuery q
   = (== Right q)
-  . parseOnly (queryParser @record)
+  . parseOnly (flip runReaderT mempty $ queryParser @record)
   . BS8.pack
   . render
   $ pprQuery @record q
@@ -33,6 +36,20 @@ main = hspec $ do
 
   describe "invalid arguments" $ do
     it "should fail if passed a fake argument" $ do
-      parseOnly (queryParser @User) "{ userId(NOT_A_REAL_ARG: False) }"
+      parseOnly (flip runReaderT mempty $ queryParser @User) "{ userId(NOT_A_REAL_ARG: False) }"
         `shouldSatisfy` isLeft
+
+  describe "variables" $ do
+    it "should fail if referencing an unknown var" $ do
+      parseOnly (flip runReaderT mempty $ queryParser @User) "{ userId(arg: $missing_var) }"
+        `shouldSatisfy` isLeft
+    it "should inline a known variable" $ do
+      parseOnly (flip runReaderT (M.singleton "known" "\"a string\"")
+                   $ queryParser @User)
+                "{ userId(arg: $known) }"
+        `shouldBe` Right ( User (Just ((Arg $ Just "a string") :@@ ANil, ()))
+                                Nothing
+                                Nothing
+                                Nothing
+                         )
 


### PR DESCRIPTION
We now pass in a `ReaderT (Map String String)` into the parser corresponding to key vals for the variables. In the future this should be a `Map String Value` corresponding to JSON, but let's do one step at a time. The argument parser now checks for a leading `$`, and if it finds it, parses an identifier it then looks up in the `Map`. Tests included!

Fixes #16 