### PR TITLE
Use hspec discovery

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -65,11 +65,13 @@ library:
 
 tests:
   gql-test:
-    main: Spec.hs
+    main: Main.hs
     source-dirs: test
     ghc-options:
       - -threaded
       - -rtsopts
       - -with-rtsopts=-N
+    build-tools:
+      - hspec-discover >= 2.0
     dependencies:
       - gql

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -1,33 +1,19 @@
+module ParserSpec where
+
 import           Control.Monad.Reader
 import           Data.Attoparsec.ByteString.Char8
 import qualified Data.ByteString.Char8 as BS8
 import           Data.Either
 import qualified Data.Map as M
-import           GHC.Generics
-import           Test.Hspec hiding (Arg)
+import           Test.Hspec
 import           Test.QuickCheck
 import           TestData
 import           Text.PrettyPrint.HughesPJ
 import           Weft.Generics.PprQuery
 import           Weft.Generics.QueryParser
-import           Weft.Generics.Resolve
 import           Weft.Internal.Types
 import           Weft.Types
 
-data Tester ts = Tester
-  { testFoo :: Magic ts (Arg "name" String -> String)
-  , testBar :: Magic ts Int
-  } deriving Generic
-
-deriving instance AllHave Show (Tester ts) => Show (Tester ts)
-deriving instance AllHave Eq (Tester ts)   => Eq (Tester ts)
-
-
-testerResolver :: Tester 'Resolver
-testerResolver = Tester
-  { testFoo = pure . getArg
-  , testBar = pure 5
-  }
 
 testQuery
     :: ( Eq (record 'Query)
@@ -42,23 +28,8 @@ testQuery q
   $ pprQuery q
 
 
-main :: IO ()
-main = hspec $ do
-  describe "resolver" $ do
-    it "should not crash with an impossible case" $ do
-      res <- resolve testerResolver $ Tester Nothing $ Just (ANil, ())
-      res `shouldBe` Tester Nothing (Just 5)
-
-    it "should resolve arg fields" $ do
-      res <- resolve testerResolver $ Tester (Just (Arg "sandy":@@ ANil, ())) Nothing
-      res `shouldBe` Tester (Just "sandy") Nothing
-
-    it "should resolve everything" $ do
-      res <- resolve testerResolver $ Tester (Just (Arg "sandy":@@ ANil, ()))
-                                             (Just (ANil, ()))
-      res `shouldBe` Tester (Just "sandy") (Just 5)
-
-
+spec :: Spec
+spec = do
   describe "roundtrip parser" $ do
     it "should roundtrip for User" $
       property $ testQuery @User

--- a/test/ResolverSpec.hs
+++ b/test/ResolverSpec.hs
@@ -1,0 +1,40 @@
+module ResolverSpec where
+
+import           GHC.Generics
+import           Test.Hspec hiding (Arg)
+import           Weft.Generics.Resolve
+import           Weft.Internal.Types
+import           Weft.Types
+
+
+data Tester ts = Tester
+  { testFoo :: Magic ts (Arg "name" String -> String)
+  , testBar :: Magic ts Int
+  } deriving Generic
+
+deriving instance AllHave Show (Tester ts) => Show (Tester ts)
+deriving instance AllHave Eq (Tester ts)   => Eq (Tester ts)
+
+
+testerResolver :: Tester 'Resolver
+testerResolver = Tester
+  { testFoo = pure . getArg
+  , testBar = pure 5
+  }
+
+
+spec :: Spec
+spec = describe "resolver" $ do
+  it "should not crash with an impossible case" $ do
+    res <- resolve testerResolver $ Tester Nothing $ Just (ANil, ())
+    res `shouldBe` Tester Nothing (Just 5)
+
+  it "should resolve arg fields" $ do
+    res <- resolve testerResolver $ Tester (Just (Arg "sandy":@@ ANil, ())) Nothing
+    res `shouldBe` Tester (Just "sandy") Nothing
+
+  it "should resolve everything" $ do
+    res <- resolve testerResolver $ Tester (Just (Arg "sandy":@@ ANil, ()))
+                                           (Just (ANil, ()))
+    res `shouldBe` Tester (Just "sandy") (Just 5)
+


### PR DESCRIPTION
This turns on hspec discovery, meaning we can just add new `*Spec.hs` files to `test/` that define a `spec :: Spec` value, and everything will get hooked up automatically.