### PR TITLE
Test allTypes and that our generics instantiate

### DIFF
--- a/src/TestData.hs
+++ b/src/TestData.hs
@@ -6,7 +6,6 @@
 module TestData where
 
 import Weft.Types
-import GHC.Generics
 import Test.QuickCheck
 
 newtype Id = Id String deriving (Generic, Show, Eq, Ord, Arbitrary)

--- a/src/Weft/Generics/QueryParser.hs
+++ b/src/Weft/Generics/QueryParser.hs
@@ -1,6 +1,7 @@
 module Weft.Generics.QueryParser
   ( HasQueryParser
   , queryParser
+  , Vars
   ) where
 
 import           Control.Applicative

--- a/src/Weft/Types.hs
+++ b/src/Weft/Types.hs
@@ -4,6 +4,7 @@ module Weft.Types
   , TypeState (..)
   , module Weft.Types
   , module Weft.Generics.RecordGen
+  , Generic
   ) where
 
 import Data.Kind

--- a/test/AllTypesSpec.hs
+++ b/test/AllTypesSpec.hs
@@ -1,0 +1,59 @@
+module AllTypesSpec where
+
+import Data.List
+import Test.Hspec hiding (Arg)
+import Text.PrettyPrint.HughesPJ (render)
+import Weft.Generics.AllTypes
+import Weft.Types
+
+newtype Id = Id String deriving (Generic, Show, Eq, Ord)
+newtype Name = Name String deriving (Generic, Show, Eq, Ord)
+
+data User ts = User
+  { userId         :: Magic ts (Arg "arg" (Maybe String) -> Id)
+  , userName       :: Magic ts Name
+  , userBestFriend :: Magic ts (Arg "arg" (Maybe String) -> User ts)
+  , userFriends    :: Magic ts [User ts]
+  , userAccount    :: Magic ts (Account ts)
+  , userFingers    :: Magic ts [Finger ts]
+  } deriving (Generic)
+
+deriving instance AllHave Show (User ts) => Show (User ts)
+deriving instance AllHave Eq (User ts)   => Eq (User ts)
+
+data Account ts = Account
+  { accountBalance :: Magic ts (Arg "num" (Maybe Int) -> Int)
+  } deriving (Generic)
+
+deriving instance AllHave Show (Account ts) => Show (Account ts)
+deriving instance AllHave Eq (Account ts)   => Eq (Account ts)
+
+data Finger ts = Finger
+  { fingers :: Magic ts (Account ts)
+  } deriving (Generic)
+
+deriving instance AllHave Show (Finger ts) => Show (Finger ts)
+deriving instance AllHave Eq (Finger ts)   => Eq (Finger ts)
+
+
+main = hspec spec
+
+
+spec :: Spec
+spec = do
+  describe "allTypes" $ do
+    it "should find downstream types" $ do
+      let all_types = sort $ fmap render $ allTypes @User
+
+      length all_types `shouldBe` 3
+      all_types !! 0 `shouldSatisfy` isPrefixOf "type Account"
+      all_types !! 1 `shouldSatisfy` isPrefixOf "type Finger"
+      all_types !! 2 `shouldSatisfy` isPrefixOf "type User"
+
+    it "should not find upstream types" $ do
+      let all_types = fmap render $ allTypes @Account
+
+      length all_types `shouldBe` 1
+      all_types !! 0 `shouldSatisfy` isPrefixOf "type Account"
+
+

--- a/test/GenericsSpec.hs
+++ b/test/GenericsSpec.hs
@@ -1,0 +1,98 @@
+module GenericsSpec where
+
+import Control.Monad.Reader
+import Data.Attoparsec.ByteString.Char8
+import Test.Hspec hiding (Arg)
+import Text.PrettyPrint.HughesPJ (Doc)
+import Weft.Generics.AllTypes
+import Weft.Generics.EmptyQuery
+import Weft.Generics.Hydrate
+import Weft.Generics.PprQuery
+import Weft.Generics.PprSchema
+import Weft.Generics.QueryParser
+import Weft.Generics.Resolve
+import Weft.Generics.Schema
+import Weft.Types
+
+
+newtype Id = Id String deriving (Generic, Show, Eq, Ord)
+newtype Name = Name String deriving (Generic, Show, Eq, Ord)
+
+data User ts = User
+  { userId         :: Magic ts (Arg "arg" (Maybe String) -> Id)
+  , userName       :: Magic ts Name
+  , userBestFriend :: Magic ts (Arg "arg" (Maybe String) -> User ts)
+  , userFriends    :: Magic ts [User ts]
+  , userAccount    :: Magic ts (Account ts)
+  } deriving (Generic)
+
+deriving instance AllHave Show (User ts) => Show (User ts)
+deriving instance AllHave Eq (User ts)   => Eq (User ts)
+
+data Account ts = Account
+  { accountBalance :: Magic ts (Arg "num" (Maybe Int) -> Int)
+  } deriving (Generic)
+
+deriving instance AllHave Show (Account ts) => Show (Account ts)
+deriving instance AllHave Eq (Account ts)   => Eq (Account ts)
+
+
+------------------------------------------------------------------------------
+-- | This module just instantiates a bunch of our generics at concrete types to
+-- make sure we didn't miss any cases.
+spec :: Spec
+spec = it "should compile when we instantiate our generics to concrete types" $
+  True `shouldBe` True
+
+
+------------------------------------------------------------------------------
+
+
+allTypesUser :: [Doc]
+allTypesUser = allTypes @User
+
+allTypesAccount :: [Doc]
+allTypesAccount = allTypes @Account
+
+emptyQueryUser :: User 'Query
+emptyQueryUser = emptyQuery
+
+emptyQueryAccount :: Account 'Query
+emptyQueryAccount = emptyQuery
+
+hydrateUser :: User 'Data -> User 'Query -> User 'Response
+hydrateUser = hydrate
+
+hydrateAccount :: Account 'Data -> Account 'Query -> Account 'Response
+hydrateAccount = hydrate
+
+pprQueryUser :: User 'Query -> Doc
+pprQueryUser = pprQuery
+
+pprQueryAccount :: Account 'Query -> Doc
+pprQueryAccount = pprQuery
+
+pprSchemaUser :: User 'Schema -> Doc
+pprSchemaUser = pprSchema
+
+pprSchemaAccount :: Account 'Schema -> Doc
+pprSchemaAccount = pprSchema
+
+queryParserUser :: ReaderT Vars Parser (User 'Query)
+queryParserUser = queryParser
+
+queryParserAccount :: ReaderT Vars Parser (Account 'Query)
+queryParserAccount = queryParser
+
+resolveUser :: User 'Resolver -> User 'Query -> IO (User 'Response)
+resolveUser = resolve
+
+resolveAccount :: Account 'Resolver -> Account 'Query -> IO (Account 'Response)
+resolveAccount = resolve
+
+schemaUser :: User 'Schema
+schemaUser = schema
+
+schemaAccount :: Account 'Schema
+schemaAccount = schema
+

--- a/test/ResolverSpec.hs
+++ b/test/ResolverSpec.hs
@@ -1,10 +1,9 @@
 module ResolverSpec where
 
-import           GHC.Generics
-import           Test.Hspec hiding (Arg)
-import           Weft.Generics.Resolve
-import           Weft.Internal.Types
-import           Weft.Types
+import Test.Hspec hiding (Arg)
+import Weft.Generics.Resolve
+import Weft.Internal.Types
+import Weft.Types
 
 
 data Tester ts = Tester


### PR DESCRIPTION
New test modules. 

One is on the result of `allTypes` which dumps schemas for external non-haskell use. 

The other just instantiates all of our generics to make sure that we aren't missing any cases.