### PR TITLE
Do a error on input outputs

### DIFF
--- a/src/Weft/Generics/JSONResponse.hs
+++ b/src/Weft/Generics/JSONResponse.hs
@@ -33,15 +33,15 @@ combine :: Value -> Value -> Value
 combine (Object a) (Object b) = Object $ a <> b
 combine _ _                   = error "combine failed in JSONResponse, this should not have happened"
 
-instance {-# OVERLAPPING #-} (HasJSONResponse record, Typeable record) 
+instance {-# OVERLAPPING #-} (HasJSONResponse record, Typeable record)
       => GJsonResponse (K1 x (M.Map T.Text [record 'Response])) where
     gJsonResponse (K1 r) = toJSON $ fmap jsonResponse <$> r
 
-instance {-# OVERLAPPING #-} (HasJSONResponse record, Typeable record) 
+instance {-# OVERLAPPING #-} (HasJSONResponse record, Typeable record)
       => GJsonResponse (K1 x (M.Map T.Text (record 'Response))) where
     gJsonResponse (K1 r) = toJSON $ jsonResponse <$> r
 
-instance {-# OVERLAPPING #-} (Typeable record, ToJSON record) 
+instance {-# OVERLAPPING #-} (Typeable record, ToJSON record)
       => GJsonResponse (K1 x (M.Map T.Text record)) where
     gJsonResponse (K1 r) = toJSON r
 

--- a/src/Weft/Internal/ArgTypes.hs
+++ b/src/Weft/Internal/ArgTypes.hs
@@ -27,7 +27,8 @@ import           Weft.Internal.Types
 
 
 ------------------------------------------------------------------------------
--- |
+-- | Make sure to add a case for 'Weft.Internal.Types.MagicQueryInputOutput'
+-- when adding cases here
 class IsArgType a where
   pprArg :: Arg n a -> Doc
   parseArgValue :: ReaderT Vars Parser a

--- a/src/Weft/Internal/Types.hs
+++ b/src/Weft/Internal/Types.hs
@@ -62,7 +62,7 @@ type family MagicQueryResult (use :: *) (u :: ([(Symbol, *)], *)) :: * where
   MagicQueryResult _ '(ts, NonEmpty (record 'Query)) = (Args ts, record 'Query)
   MagicQueryResult _ '(ts, [record 'Query])          = (Args ts, record 'Query)
   MagicQueryResult _ '(ts, record 'Query)            = (Args ts, record 'Query)
-  MagicQueryResult use '(ts, a)                        = (Args ts, MagicQueryInputOutput a use)
+  MagicQueryResult use '(ts, a)                      = (Args ts, MagicQueryInputOutput a use)
 
 type family MagicQueryInputOutput (t :: *) (use :: *) :: * where
   MagicQueryInputOutput Int     _ = ()

--- a/test/JSONResponseSpec.hs
+++ b/test/JSONResponseSpec.hs
@@ -4,38 +4,15 @@
 
 module JSONResponseSpec where
 
-import           Test.Hspec hiding (Arg)
-import           Weft.Internal.Types
-import           Weft.Generics.Hydrate
-import           Weft.Generics.JSONResponse
-import           Test.QuickCheck
-import qualified Data.Map as M
 import           Data.Aeson
 import           Data.ByteString.Lazy
-import           GHC.Generics
+import qualified Data.Map as M
+import           Test.Hspec hiding (Arg)
+import           TestData
+import           Weft.Generics.Hydrate
+import           Weft.Generics.JSONResponse
+import           Weft.Internal.Types
 
-newtype Id = Id Int
-  deriving stock (Generic, Show, Eq, Ord)
-  deriving newtype (Arbitrary, ToJSON)
-  deriving Read via (Int)
-
-newtype Name = Name String
-  deriving stock (Generic, Show, Eq, Ord)
-  deriving newtype (Arbitrary, ToJSON)
-
-data User ts = User
-  { userId         :: Magic ts (Arg "arg" (Maybe Int) -> Id)
-  , userName       :: Magic ts Name
-  , userBestFriend :: Magic ts (Arg "arg" (Maybe Int) -> User ts)
-  , userFriends    :: Magic ts [User ts]
-  } deriving (Generic)
-
-
-jonathan :: User 'Data
-jonathan = User { userId = (Id 1), userName = ( Name "Jonathan"), userBestFriend = sandy, userFriends = [] }
-
-sandy :: User 'Data
-sandy = User { userId = (Id 2), userName = ( Name "Sandy"), userBestFriend = jonathan, userFriends = []}
 
 userQuery :: User 'Query
 userQuery = User
@@ -45,26 +22,29 @@ userQuery = User
                                                   , userBestFriendQ
                                                   )
   , userFriends    = M.empty
+  , userFingers    = M.empty
   }
 
 userBestFriendQ :: User 'Query
-userBestFriendQ = User 
+userBestFriendQ = User
   { userId         = M.empty
   , userName       = M.singleton "userName" (ANil, ())
   , userBestFriend = M.empty
   , userFriends    = M.empty
+  , userFingers    = M.empty
   }
 
 mockJonathanJSON :: ByteString
-mockJonathanJSON = "{\"userName\":\"Jonathan\",\"userId\":1,\"userBestFriend\":{\"userName\":\"Sandy\"}}"
+mockJonathanJSON = "{\"userName\":\"Jonathan\",\"userId\":\"1\",\"userBestFriend\":{\"userName\":\"Sandy\"}}"
 
 mockSandyJSON :: ByteString
-mockSandyJSON = "{\"userName\":\"Sandy\",\"userId\":2,\"userBestFriend\":{\"userName\":\"Jonathan\"}}"
+mockSandyJSON = "{\"userName\":\"Sandy\",\"userId\":\"2\",\"userBestFriend\":{\"userName\":\"Jonathan\"}}"
 
 spec :: Spec
 spec = do
   describe "parses json from response" $ do
-    it "should parse JSON from Sandy" $ 
-      encode (jsonResponse (hydrate sandy userQuery)) `shouldBe` mockSandyJSON
+    it "should parse JSON from Sandy" $
+      encode (jsonResponse $ hydrate sandy userQuery) `shouldBe` mockSandyJSON
     it "should parse JSON from Jonathan" $ do
-      encode (jsonResponse (hydrate jonathan userQuery)) `shouldBe` mockJonathanJSON
+      encode (jsonResponse $ hydrate jonathan userQuery) `shouldBe` mockJonathanJSON
+


### PR DESCRIPTION
Since input types aren't magic, we don't have a place we can stick our subquery juice. So instead we shoot a compiler error if you try.